### PR TITLE
[Feature] Adding unit tests for indexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ add_subdirectory(external)
 add_library(bliss OBJECT
     ${CMAKE_SOURCE_DIR}/src/bliss/util/timer.h
     ${CMAKE_SOURCE_DIR}/src/bliss/util/reader.h
+    ${CMAKE_SOURCE_DIR}/src/bliss/util/args.h
+    ${CMAKE_SOURCE_DIR}/src/bliss/util/config.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bliss_index.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_lipp.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_alex.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+enable_testing()
+
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     ADD_DEFINITIONS(-DDEBUG)
 endif()
@@ -33,6 +35,8 @@ endif()
 #   add external libs (after git submodule init)
 # =============================================================================
 add_subdirectory(external)
+
+add_subdirectory(tests)
 
 # =============================================================================
 # HEADER bliss

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bliss_benchmark
+# BLISS Benchmark
 The purpose of this program is to benchmark the sortedness performance on various indexes.\
 This research project is part of the [Data-intensive Systems and Computing (DiSC) lab](https://disc.bu.edu/) at Boston University.
 
@@ -36,3 +36,49 @@ The program currently accepts the following parameters:
   -v, --verbosity [=arg(=1)]       Verbosity [0: Info| 1: Debug | 2: Trace] (default: 0)
   -i, --index arg                  Index type (alex|lipp) (default: btree)
 ```
+
+## Contributing to this Project
+If you are interested in contributing to this benchmarking effort, 
+please reach out to [Aneesh Raman](aneeshr@bu.edu) / [Andy Huynh](ndhuynh@bu.edu) / [Manos Athanassoulis](mathan@bu.edu). 
+
+### Integrating a New Index
+We primarily import indexes as CMake libraries, before integrating them into the benchmarking framework. 
+
+#### Importing using CMake
+Import the library in `external/CMakeLists.txt`. Then, link the library to the `bliss` executable in the `CMakeLists.txt` file in the root project directory. 
+
+#### Building the Adapter
+Every index in the framework uses an adapter to interact with the benchmark. These adapters are found under `src/bliss`. 
+
+- The abstract class for the adapter is found at `src/bliss/bliss_index.h`. 
+- Add the adapter code for the new index `<abc>` in its own file called `bench_abc.h` under `src/bliss`.
+
+#### Adding to the Benchmark
+The benchmark code is found at `bliss_bench.cpp`. To add the index to the benchmark: 
+
+- Include the relevant header file, e.g., `#include bliss/bench_abc.h`. 
+- In the `main()` function, add the additional condition when checking `config.index` for parsing the new index. 
+
+#### Adding Unit Tests
+Currently, we support basic unit tests with `put()` and `get()` operations in the benchmark. 
+
+For the newly integrated index (e.g., `abc`), add relevant unit tests under the `tests/` folder. 
+- Create a new directory under `tests/` for the index `abc` by prefixing the folder with `test_*` (i.e., `mkdir tests/test_abc`).
+- Each index folder gets its own `CMakeLists.txt` file that will link with the outer `tests/CMakeLists.txt` file. 
+- Copy the `CMakeLists.txt` file from one of the existing indexes into `tests/abc` (i.e., `cp tests/test_btree/CMakeLists.txt tests/test_abc/`). 
+- Modify `tests/CMakeLists.txt` to include the new subdirectory (i.e., add a new line with `add subdirectory(test_abc)`). 
+
+You can create one or multiple cpp files under `tests/test_abc/` for your unit tests. 
+
+- Name every unit test file prefixed with the index name (e.g., `abc_tests.cpp`). 
+- Include the header file `bliss_index_tests.h` in your test file to import common util code. 
+
+**You may refer to `tests/test_btree/btree_tests.cpp` for samples.**
+
+## Issues & Additional Information
+You may report bugs/issues directly on Github [here](https://github.com/BU-DiSC/bliss_benchmark/issues). 
+
+For additional information, contact: 
+- [Aneesh Raman](aneeshr@bu.edu)
+- [Andy Huynh](ndhuynh@bu.edu)
+- [Manos Athanassoulis](mathan@bu.edu)

--- a/src/bliss/util/args.h
+++ b/src/bliss/util/args.h
@@ -1,5 +1,5 @@
-#ifndef ARGS_H
-#define ARGS_H
+#ifndef BLISS_ARGS_H
+#define BLISS_ARGS_H
 #include <cxxopts.hpp>
 #include <iostream>
 #include <string>

--- a/src/bliss/util/args.h
+++ b/src/bliss/util/args.h
@@ -1,0 +1,65 @@
+#ifndef ARGS_H
+#define ARGS_H
+#include <cxxopts.hpp>
+#include <iostream>
+#include <string>
+
+#include "bliss/util/config.h"
+
+using namespace bliss::utils::config;
+
+namespace bliss {
+namespace utils {
+namespace args {
+BlissConfig parse_args(int argc, char *argv[]) {
+    BlissConfig config;
+    cxxopts::Options options(
+        "bliss", "BLISS: Benchmarking Learned Index Structures for Sortedness");
+
+    try {
+        options.add_options()("d,data_file", "Path to the data file",
+                              cxxopts::value<std::string>())(
+            "p,preload_factor", "Preload factor",
+            cxxopts::value<double>()->default_value("0.5"))(
+            "w,write_factor", "Write factor",
+            cxxopts::value<double>()->default_value("0.25"))(
+            "r,read_factor", "Read factor",
+            cxxopts::value<double>()->default_value("0.1"))(
+            "m,mixed_read_write_ratio", "Read write ratio",
+            cxxopts::value<double>()->default_value("0.5"))(
+            "s,seed", "Random Seed value",
+            cxxopts::value<int>()->default_value("0"))(
+            "v,verbosity", "Verbosity [0: Info| 1: Debug | 2: Trace]",
+            cxxopts::value<int>()->default_value("0")->implicit_value("1"))(
+            "i,index", "Index type [alex | lipp | btree | bepstree | lsm]",
+            cxxopts::value<std::string>()->default_value("btree"))(
+            "file_type", "Input file type [binary | txt]",
+            cxxopts::value<std::string>()->default_value("txt"))(
+            "use_preload", "Use index defined preload",
+            cxxopts::value<bool>()->default_value("false"));
+
+        auto result = options.parse(argc, argv);
+        config = {
+            .data_file = result["data_file"].as<std::string>(),
+            .preload_factor = result["preload_factor"].as<double>(),
+            .write_factor = result["write_factor"].as<double>(),
+            .read_factor = result["read_factor"].as<double>(),
+            .mixed_read_write_ratio =
+                result["mixed_read_write_ratio"].as<double>(),
+            .seed = result["seed"].as<int>(),
+            .verbosity = result["verbosity"].as<int>(),
+            .index = result["index"].as<std::string>(),
+            .file_type = result["file_type"].as<std::string>(),
+            .use_preload = result["use_preload"].as<bool>(),
+        };
+    } catch (const std::exception &e) {
+        std::cerr << "Error: " << e.what() << std::endl;
+        std::cerr << options.help() << std::endl;
+        exit(1);
+    }
+    return config;
+}
+}  // namespace args
+}  // namespace utils
+}  // namespace bliss
+#endif

--- a/src/bliss/util/config.h
+++ b/src/bliss/util/config.h
@@ -1,0 +1,38 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <spdlog/common.h>
+
+#include <string>
+
+namespace bliss {
+namespace utils {
+namespace config {
+struct BlissConfig {
+    std::string data_file;
+    double preload_factor;
+    double write_factor;
+    double read_factor;
+    double mixed_read_write_ratio;
+    int seed;
+    int verbosity;
+    std::string index;
+    std::string file_type;
+    bool use_preload;
+};
+
+void display_config(BlissConfig config) {
+    spdlog::trace("Data File: {}", config.data_file);
+    spdlog::trace("Preload Factor: {}", config.preload_factor);
+    spdlog::trace("Write Factor: {}", config.write_factor);
+    spdlog::trace("Read Factor: {}", config.read_factor);
+    spdlog::trace("Read Write Ratio: {}", config.mixed_read_write_ratio);
+    spdlog::trace("Verbosity {}", config.verbosity);
+    spdlog::trace("Index: {}", config.index);
+    spdlog::trace("File type: {}", config.file_type);
+}
+}  // namespace config
+}  // namespace utils
+}  // namespace bliss
+
+#endif

--- a/src/bliss/util/config.h
+++ b/src/bliss/util/config.h
@@ -1,5 +1,5 @@
-#ifndef CONFIG_H
-#define CONFIG_H
+#ifndef BLISS_CONFIG_H
+#define BLISS_CONFIG_H
 
 #include <spdlog/common.h>
 

--- a/src/bliss/util/execute.h
+++ b/src/bliss/util/execute.h
@@ -1,5 +1,5 @@
-#ifndef EXECUTE_H
-#define EXECUTE_H
+#ifndef BLISS_EXECUTE_H
+#define BLISS_EXECUTE_H
 #include <iostream>
 #include <random>
 #include <vector>

--- a/src/bliss/util/execute.h
+++ b/src/bliss/util/execute.h
@@ -1,0 +1,17 @@
+#ifndef EXECUTE_H
+#define EXECUTE_H
+#include <iostream>
+#include <random>
+#include <vector>
+
+#include "bliss/bliss_index.h"
+
+typedef unsigned long key_type;
+typedef unsigned long value_type;
+
+namespace bliss {
+namespace utils {
+namespace executor {}  // namespace executor
+}  // namespace utils
+}  // namespace bliss
+#endif

--- a/src/bliss/util/execute.h
+++ b/src/bliss/util/execute.h
@@ -11,7 +11,34 @@ typedef unsigned long value_type;
 
 namespace bliss {
 namespace utils {
-namespace executor {}  // namespace executor
+namespace executor {
+void execute_inserts(bliss::BlissIndex<key_type, value_type> &tree,
+                     std::vector<key_type>::iterator &start,
+                     std::vector<key_type>::iterator &end, int seed = 0) {
+    spdlog::trace("Executing Inserts");
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<value_type> dist(0, 1);
+
+    auto num_keys = end - start;
+    for (auto &curr = start; curr != end; ++curr) {
+        tree.put(*curr, std::round(dist(gen) * num_keys));
+    }
+}
+
+void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
+                             std::vector<key_type> &data, int num_reads,
+                             int seed = 0) {
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<int> dist(0, 1);
+
+    size_t key_idx;
+    for (auto blank = 0; blank < num_reads; blank++) {
+        key_idx = std::round(dist(gen) * (data.size() - 1));
+        tree.get(data.at(key_idx));
+    }
+}
+
+}  // namespace executor
 }  // namespace utils
 }  // namespace bliss
 #endif

--- a/src/bliss_bench.cpp
+++ b/src/bliss_bench.cpp
@@ -17,36 +17,11 @@
 #include "bliss/util/timer.h"
 
 using namespace bliss::utils;
-void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
-                             std::vector<key_type> &data, int num_reads,
-                             int seed = 0) {
-    std::mt19937 gen(seed);
-    std::uniform_int_distribution<int> dist(0, 1);
-
-    size_t key_idx;
-    for (auto blank = 0; blank < num_reads; blank++) {
-        key_idx = std::round(dist(gen) * (data.size() - 1));
-        tree.get(data.at(key_idx));
-    }
-}
 
 void execute_bulkload(bliss::BlissIndex<key_type, value_type> &tree,
                       std::vector<std::pair<key_type, value_type>> &values) {
     spdlog::trace("Bulkloading values");
     tree.bulkload(values);
-}
-
-void execute_inserts(bliss::BlissIndex<key_type, value_type> &tree,
-                     std::vector<key_type>::iterator &start,
-                     std::vector<key_type>::iterator &end, int seed = 0) {
-    spdlog::trace("Executing Inserts");
-    std::mt19937 gen(seed);
-    std::uniform_int_distribution<value_type> dist(0, 1);
-
-    auto num_keys = end - start;
-    for (auto &curr = start; curr != end; ++curr) {
-        tree.put(*curr, std::round(dist(gen) * num_keys));
-    }
 }
 
 void execute_mixed_workload(bliss::BlissIndex<key_type, key_type> &tree,
@@ -128,8 +103,9 @@ void workload_executor(bliss::BlissIndex<key_type, value_type> &tree,
             std::chrono::duration_cast<std::chrono::nanoseconds>(
                 std::chrono::high_resolution_clock::now() - start)
                 .count();
-        preload_time = time_function(
-            [&]() { execute_inserts(tree, preload_start, preload_end); });
+        preload_time = time_function([&]() {
+            executor::execute_inserts(tree, preload_start, preload_end);
+        });
     }
     spdlog::info("Preload Creation Time (ns): {}", preload_creation_time);
     spdlog::info("Preload Time (ns): {}", preload_time);
@@ -138,8 +114,8 @@ void workload_executor(bliss::BlissIndex<key_type, value_type> &tree,
     spdlog::debug("Writing {} items", num_writes);
     auto write_start = preload_end;
     auto write_end = write_start + num_writes;
-    auto write_time =
-        time_function([&]() { execute_inserts(tree, write_start, write_end); });
+    auto write_time = time_function(
+        [&]() { executor::execute_inserts(tree, write_start, write_end); });
     spdlog::info("Write Time (ns): {}", write_time);
 
     // Timing for mixed workloads running
@@ -154,8 +130,9 @@ void workload_executor(bliss::BlissIndex<key_type, value_type> &tree,
 
     // Timing for reads on index
     spdlog::debug("Reading {} items", num_reads);
-    auto read_time = time_function(
-        [&]() { execute_non_empty_reads(tree, data, num_reads, seed); });
+    auto read_time = time_function([&]() {
+        executor::execute_non_empty_reads(tree, data, num_reads, seed);
+    });
     spdlog::info("Read Time (ns): {}", read_time);
 }
 

--- a/src/bliss_bench.cpp
+++ b/src/bliss_bench.cpp
@@ -10,85 +10,13 @@
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
 #include "bliss/bliss_index.h"
+#include "bliss/util/args.h"
+#include "bliss/util/config.h"
+#include "bliss/util/execute.h"
 #include "bliss/util/reader.h"
 #include "bliss/util/timer.h"
 
-typedef unsigned long key_type;
-typedef unsigned long value_type;
-
-struct BlissConfig {
-    std::string data_file;
-    double preload_factor;
-    double write_factor;
-    double read_factor;
-    double mixed_read_write_ratio;
-    int seed;
-    int verbosity;
-    std::string index;
-    std::string file_type;
-    bool use_preload;
-};
-
-BlissConfig parse_args(int argc, char *argv[]) {
-    BlissConfig config;
-    cxxopts::Options options(
-        "bliss", "BLISS: Benchmarking Learned Index Structures for Sortedness");
-
-    try {
-        options.add_options()("d,data_file", "Path to the data file",
-                              cxxopts::value<std::string>())(
-            "p,preload_factor", "Preload factor",
-            cxxopts::value<double>()->default_value("0.5"))(
-            "w,write_factor", "Write factor",
-            cxxopts::value<double>()->default_value("0.25"))(
-            "r,read_factor", "Read factor",
-            cxxopts::value<double>()->default_value("0.1"))(
-            "m,mixed_read_write_ratio", "Read write ratio",
-            cxxopts::value<double>()->default_value("0.5"))(
-            "s,seed", "Random Seed value",
-            cxxopts::value<int>()->default_value("0"))(
-            "v,verbosity", "Verbosity [0: Info| 1: Debug | 2: Trace]",
-            cxxopts::value<int>()->default_value("0")->implicit_value("1"))(
-            "i,index", "Index type [alex | lipp | btree | bepstree | lsm]",
-            cxxopts::value<std::string>()->default_value("btree"))(
-            "file_type", "Input file type [binary | txt]",
-            cxxopts::value<std::string>()->default_value("txt"))(
-            "use_preload", "Use index defined preload",
-            cxxopts::value<bool>()->default_value("false"));
-
-        auto result = options.parse(argc, argv);
-        config = {
-            .data_file = result["data_file"].as<std::string>(),
-            .preload_factor = result["preload_factor"].as<double>(),
-            .write_factor = result["write_factor"].as<double>(),
-            .read_factor = result["read_factor"].as<double>(),
-            .mixed_read_write_ratio =
-                result["mixed_read_write_ratio"].as<double>(),
-            .seed = result["seed"].as<int>(),
-            .verbosity = result["verbosity"].as<int>(),
-            .index = result["index"].as<std::string>(),
-            .file_type = result["file_type"].as<std::string>(),
-            .use_preload = result["use_preload"].as<bool>(),
-        };
-    } catch (const std::exception &e) {
-        std::cerr << "Error: " << e.what() << std::endl;
-        std::cerr << options.help() << std::endl;
-        exit(1);
-    }
-    return config;
-}
-
-void display_config(BlissConfig config) {
-    spdlog::trace("Data File: {}", config.data_file);
-    spdlog::trace("Preload Factor: {}", config.preload_factor);
-    spdlog::trace("Write Factor: {}", config.write_factor);
-    spdlog::trace("Read Factor: {}", config.read_factor);
-    spdlog::trace("Read Write Ratio: {}", config.mixed_read_write_ratio);
-    spdlog::trace("Verbosity {}", config.verbosity);
-    spdlog::trace("Index: {}", config.index);
-    spdlog::trace("File type: {}", config.file_type);
-}
-
+using namespace bliss::utils;
 void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
                              std::vector<key_type> &data, int num_reads,
                              int seed = 0) {
@@ -100,27 +28,6 @@ void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
         key_idx = std::round(dist(gen) * (data.size() - 1));
         tree.get(data.at(key_idx));
     }
-}
-
-std::vector<std::pair<key_type, value_type>> create_preload_vec(
-    std::vector<key_type>::iterator &start,
-    std::vector<key_type>::iterator &end, bool sort_values = true,
-    int value_generator_seed = 0) {
-    std::mt19937 gen(value_generator_seed);
-    std::uniform_int_distribution<key_type> dist(0, 2 << 16);
-    std::vector<std::pair<key_type, value_type>> vec;
-
-    if (sort_values) {
-        spdlog::trace("Sorting values");
-        std::stable_sort(start, end);
-    }
-
-    spdlog::trace("Creating key-value pairs");
-    for (auto curr = start; curr != end; ++curr) {
-        vec.push_back(std::make_pair(*curr, dist(gen)));
-    }
-
-    return vec;
 }
 
 void execute_bulkload(bliss::BlissIndex<key_type, value_type> &tree,
@@ -170,10 +77,30 @@ void execute_mixed_workload(bliss::BlissIndex<key_type, key_type> &tree,
         }
     }
 }
+std::vector<std::pair<key_type, value_type>> create_preload_vec(
+    std::vector<key_type>::iterator &start,
+    std::vector<key_type>::iterator &end, bool sort_values = true,
+    int value_generator_seed = 0) {
+    std::mt19937 gen(value_generator_seed);
+    std::uniform_int_distribution<key_type> dist(0, 2 << 16);
+    std::vector<std::pair<key_type, value_type>> vec;
+
+    if (sort_values) {
+        spdlog::trace("Sorting values");
+        std::stable_sort(start, end);
+    }
+
+    spdlog::trace("Creating key-value pairs");
+    for (auto curr = start; curr != end; ++curr) {
+        vec.push_back(std::make_pair(*curr, dist(gen)));
+    }
+
+    return vec;
+}
 
 void workload_executor(bliss::BlissIndex<key_type, value_type> &tree,
-                       std::vector<key_type> &data, const BlissConfig &config,
-                       const int seed) {
+                       std::vector<key_type> &data,
+                       const config::BlissConfig &config, const int seed) {
     size_t num_inserts = data.size();
     size_t num_preload = std::round(config.preload_factor * num_inserts);
     size_t num_writes = std::round(config.write_factor * data.size());
@@ -233,7 +160,7 @@ void workload_executor(bliss::BlissIndex<key_type, value_type> &tree,
 }
 
 int main(int argc, char *argv[]) {
-    auto config = parse_args(argc, argv);
+    auto config = args::parse_args(argc, argv);
     switch (config.verbosity) {
         case 1:
             spdlog::set_level(spdlog::level::debug);
@@ -265,7 +192,7 @@ int main(int argc, char *argv[]) {
     } else if (config.index == "btree") {
         index.reset(new bliss::BlissBTreeIndex<key_type, value_type>());
     } else {
-        spdlog::error("{} not implemented yet", config.index);
+        spdlog::error(config.index + " not implemented yet", 1);
     }
 
     workload_executor(*index, data, config, 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+include(FetchContent)
+
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG release-1.12.1
+)
+FetchContent_MakeAvailable(googletest)
+
+add_library(bliss_test_infra OBJECT 
+${CMAKE_CURRENT_SOURCE_DIR}/bliss_index_tests.h)
+
+target_include_directories(bliss_test_infra PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_subdirectory(test_alex)
+add_subdirectory(test_lipp)
+add_subdirectory(test_btree)

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -1,0 +1,46 @@
+#ifndef BLISS_INDEX_TESTS_H
+#define BLISS_INDEX_TESTS_H
+#include <alex.h>
+#include <gtest/gtest.h>
+#include <lipp.h>
+#include <spdlog/common.h>
+
+#include <cxxopts.hpp>
+#include <iostream>
+#include <string>
+
+#include "bliss/bench_alex.h"
+#include "bliss/bench_btree.h"
+#include "bliss/bench_lipp.h"
+#include "bliss/bliss_index.h"
+#include "bliss/util/args.h"
+#include "bliss/util/config.h"
+#include "bliss/util/execute.h"
+#include "bliss/util/reader.h"
+#include "bliss/util/timer.h"
+
+using namespace bliss::utils;
+
+using key_type = unsigned long;
+using value_type = unsigned long;
+
+class BlissIndexTest : public testing::Test {
+   protected:
+    std::unique_ptr<bliss::BlissIndex<key_type, value_type>> index;
+    std::string indexes[3] = {"alex", "lipp", "btree"};
+    int num_keys = 100000;
+
+    void SetUp() {}
+
+    void GenerateData(std::vector<key_type> &data, int num_keys,
+                      bool sorted = true) {
+        for (int i = 0; i < num_keys; i++) {
+            data.push_back(i);
+        }
+        if (!sorted) {
+            std::random_shuffle(data.begin(), data.end());
+        }
+    }
+};
+
+#endif

--- a/tests/test_alex/CMakeLists.txt
+++ b/tests/test_alex/CMakeLists.txt
@@ -1,0 +1,10 @@
+get_filename_component(EXEC ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+file(GLOB_RECURSE CPP_TESTS "*_tests.cpp")
+add_executable(${EXEC} ${CPP_TESTS})
+target_link_libraries(${EXEC} PRIVATE 
+bliss
+bliss_test_infra 
+GTest::gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(${EXEC})

--- a/tests/test_alex/alex_tests.cpp
+++ b/tests/test_alex/alex_tests.cpp
@@ -1,0 +1,30 @@
+#include "bliss_index_tests.h"
+
+class AlexTest : public BlissIndexTest {};
+TEST_F(AlexTest, TestAlex_Sorted) {
+    index.reset(new bliss::BlissAlexIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}
+
+TEST_F(AlexTest, TestAlex_Random) {
+    index.reset(new bliss::BlissAlexIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys, false);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}

--- a/tests/test_btree/CMakeLists.txt
+++ b/tests/test_btree/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_filename_component(EXEC ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+file(GLOB_RECURSE CPP_TESTS "*_tests.cpp")
+add_executable(${EXEC} ${CPP_TESTS})
+target_link_libraries(${EXEC} PRIVATE 
+bliss
+bliss_test_infra 
+GTest::gtest_main)
+include(GoogleTest)
+gtest_discover_tests(${EXEC})

--- a/tests/test_btree/btree_tests.cpp
+++ b/tests/test_btree/btree_tests.cpp
@@ -1,0 +1,31 @@
+#include "bliss_index_tests.h"
+
+class BTreeTest : public BlissIndexTest {};
+
+TEST_F(BTreeTest, TestBTree_Sorted) {
+    index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}
+
+TEST_F(BTreeTest, TestBTree_Random) {
+    index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys, false);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}

--- a/tests/test_lipp/CMakeLists.txt
+++ b/tests/test_lipp/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_filename_component(EXEC ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+file(GLOB_RECURSE CPP_TESTS "*_tests.cpp")
+add_executable(${EXEC} ${CPP_TESTS})
+target_link_libraries(${EXEC} PRIVATE 
+bliss
+bliss_test_infra 
+GTest::gtest_main)
+include(GoogleTest)
+gtest_discover_tests(${EXEC})

--- a/tests/test_lipp/lipp_tests.cpp
+++ b/tests/test_lipp/lipp_tests.cpp
@@ -1,0 +1,31 @@
+#include "bliss_index_tests.h"
+
+class LippTest : public BlissIndexTest {};
+
+TEST_F(LippTest, TestLipp_Sorted) {
+    index.reset(new bliss::BlissLippIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}
+
+TEST_F(LippTest, TestLipp_Random) {
+    index.reset(new bliss::BlissAlexIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys, false);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}


### PR DESCRIPTION
This PR adds a simple unit testing framework.
 
- Integrates GoogleTest.
- Tests with simple put() and get() operations.
- Each index tested with fully sorted and random data. 

The PR also **refactors** or **modifies** the following: 
- execution code from bliss_bench.cpp into util/ headers.
- Readme to include instructions on integrating a new index (along with unit tests). 

**This PR does not test for performance**

Authored by: 
- [Aneesh Raman](aneeshr@bu.edu)