### PR TITLE
[Integration] Adding ART to the benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,15 +189,19 @@ cython_debug/
 .cache
 build
 
-# IDE
+# IDE - VSCode
 .vscode/
 script/infra/__pycache__
 results.db
 data/*.data
 *.bin
 
+# IDE - IntelliJ
 .idea
 cmake-build-debug/
 src/bliss/.idea/
 
+# OS - MacOS
 db_working_home
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(bliss OBJECT
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_lipp.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_alex.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_btree.h
+    ${CMAKE_SOURCE_DIR}/src/bliss/bench_art.h
 )
 
 target_compile_features(bliss PUBLIC
@@ -63,6 +64,7 @@ target_link_libraries(bliss PUBLIC
     alex
     lipp
     tlx
+    art
 )
 
 target_include_directories(bliss PUBLIC

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -71,3 +71,17 @@ endif()
 
 add_library(tlx INTERFACE)
 target_include_directories(tlx INTERFACE ${tlx_SOURCE_DIR}/)
+
+# Adaptive Radix Tree 
+FetchContent_Declare(
+    art
+    GIT_REPOSITORY https://github.com/BU-DiSC/ART
+    GIT_TAG main
+)
+FetchContent_GetProperties(art)
+if (NOT art_POPULATED)
+    FetchContent_Populate(art)
+endif()
+
+add_library(art INTERFACE)
+target_include_directories(art INTERFACE ${art_SOURCE_DIR})

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -72,7 +72,6 @@ endif()
 add_library(tlx INTERFACE)
 target_include_directories(tlx INTERFACE ${tlx_SOURCE_DIR}/)
 
-<<<<<<< HEAD
 # Adaptive Radix Tree 
 FetchContent_Declare(
     art
@@ -86,7 +85,6 @@ endif()
 
 add_library(art INTERFACE)
 target_include_directories(art INTERFACE ${art_SOURCE_DIR})
-=======
 
 
 
@@ -102,4 +100,3 @@ endif()
 
 add_library(pgm INTERFACE)
 target_include_directories(pgm INTERFACE ${pgm_SOURCE_DIR})
->>>>>>> b87c2bfe42113c67d2b6db98089d5c63c1ec745b

--- a/src/bliss/bench_art.h
+++ b/src/bliss/bench_art.h
@@ -27,25 +27,15 @@ class BlissARTIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
     bool get(KEY_TYPE key) override {
         uint8_t ARTkey[KEY_SIZE];
         ART::loadKey(key, ARTkey);
-        std::cout << key << "" << std::endl;
-        for (size_t i = 0; i < KEY_SIZE; ++i) {
-            std::cout << static_cast<int>(ARTkey[i]) << " ";
-        }
-        std::cout << std::endl;
-        size_t testing = 2;
         ART::ArtNode* leaf =
-            ART::lookup(_index, ARTkey, testing, 0, KEY_SIZE);
-        std::cout << ART::getLeafValue(leaf) << " <- leaf value" << std::endl << std::endl;
+            ART::lookup(_index, ARTkey, KEY_SIZE, 0, KEY_SIZE);
         return leaf != nullptr && ART::isLeaf(leaf);
     }
 
     void put(KEY_TYPE key, VALUE_TYPE value) override {
         uint8_t ARTkey[KEY_SIZE];
         ART::loadKey(key, ARTkey);
-        // function signature for insert:
-        // void insert(ArtNode* ArtNode, ArtNode** nodeRef, uint8_t key[],
-        // unsigned depth, uintptr_t value, unsigned maxKeyLength)
-        ART::insert(_index, &_index, ARTkey, 0, value, KEY_SIZE);
+        ART::insert(_index, &_index, ARTkey, 0, key, KEY_SIZE);
     }
 
     void end_routine() override {}

--- a/src/bliss/bench_art.h
+++ b/src/bliss/bench_art.h
@@ -19,7 +19,7 @@ class BlissARTIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
     void bulkload(
         std::vector<std::pair<KEY_TYPE, VALUE_TYPE>> values) override {
         // expects the pairs to be pre-sorted before performing bulk load
-        for (const auto& pair : values) {
+        for (const auto pair : values) {
             put(pair.first, pair.second);
         }
     }
@@ -32,9 +32,10 @@ class BlissARTIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
             std::cout << static_cast<int>(ARTkey[i]) << " ";
         }
         std::cout << std::endl;
+        size_t testing = 2;
         ART::ArtNode* leaf =
-            ART::lookup(_index, ARTkey, sizeof(key), 0, KEY_SIZE);
-        std::cout << ART::getLeafValue(leaf) << " <- leaf value" << std::endl;
+            ART::lookup(_index, ARTkey, testing, 0, KEY_SIZE);
+        std::cout << ART::getLeafValue(leaf) << " <- leaf value" << std::endl << std::endl;
         return leaf != nullptr && ART::isLeaf(leaf);
     }
 

--- a/src/bliss/bench_art.h
+++ b/src/bliss/bench_art.h
@@ -1,0 +1,51 @@
+#ifndef BLISS_BENCH_ART
+#define BLISS_BENCH_ART
+
+#include <vector>
+
+#include "ART.h"
+#include "bliss/bliss_index.h"
+#include "spdlog/spdlog.h"
+
+namespace bliss {
+
+template <typename KEY_TYPE, typename VALUE_TYPE>
+class BlissARTIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
+   public:
+    static constexpr size_t KEY_SIZE = sizeof(KEY_TYPE);
+    ART::ArtNode* _index;
+    BlissARTIndex() { _index = nullptr; };
+
+    void bulkload(
+        std::vector<std::pair<KEY_TYPE, VALUE_TYPE>> values) override {
+        // expects the pairs to be pre-sorted before performing bulk load
+        for (const auto& pair : values) {
+            put(pair.first, pair.second);
+        }
+    }
+
+    bool get(KEY_TYPE key) override {
+        uint8_t ARTkey[KEY_SIZE];
+        ART::loadKey(key, ARTkey);
+        uint8_t depth = 0;
+        ART::ArtNode* leaf =
+            ART::lookup(_index, ARTkey, KEY_SIZE, depth, KEY_SIZE);
+        return ART::isLeaf(leaf) && ART::getLeafValue(leaf) == key;
+    }
+
+    void put(KEY_TYPE key, VALUE_TYPE value) override {
+        uint8_t ARTkey[KEY_SIZE];
+        ART::loadKey(key, ARTkey);
+
+        // function signature for insert:
+        // void insert(ArtNode* ArtNode, ArtNode** nodeRef, uint8_t key[],
+        // unsigned depth, uintptr_t value, unsigned maxKeyLength)
+        ART::insert(_index, &_index, ARTkey, 0, value, KEY_SIZE);
+    }
+
+    void end_routine() override {}
+};
+
+}  // namespace bliss
+
+#endif

--- a/src/bliss/bench_art.h
+++ b/src/bliss/bench_art.h
@@ -12,8 +12,8 @@ namespace bliss {
 template <typename KEY_TYPE, typename VALUE_TYPE>
 class BlissARTIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
    public:
-    static constexpr size_t KEY_SIZE = sizeof(KEY_TYPE);
     ART::ArtNode* _index;
+    static constexpr size_t KEY_SIZE = sizeof(KEY_TYPE);
     BlissARTIndex() { _index = nullptr; };
 
     void bulkload(
@@ -27,16 +27,20 @@ class BlissARTIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
     bool get(KEY_TYPE key) override {
         uint8_t ARTkey[KEY_SIZE];
         ART::loadKey(key, ARTkey);
-        uint8_t depth = 0;
+        std::cout << key << "" << std::endl;
+        for (size_t i = 0; i < KEY_SIZE; ++i) {
+            std::cout << static_cast<int>(ARTkey[i]) << " ";
+        }
+        std::cout << std::endl;
         ART::ArtNode* leaf =
-            ART::lookup(_index, ARTkey, KEY_SIZE, depth, KEY_SIZE);
-        return ART::isLeaf(leaf) && ART::getLeafValue(leaf) == key;
+            ART::lookup(_index, ARTkey, sizeof(key), 0, KEY_SIZE);
+        std::cout << ART::getLeafValue(leaf) << " <- leaf value" << std::endl;
+        return leaf != nullptr && ART::isLeaf(leaf);
     }
 
     void put(KEY_TYPE key, VALUE_TYPE value) override {
         uint8_t ARTkey[KEY_SIZE];
         ART::loadKey(key, ARTkey);
-
         // function signature for insert:
         // void insert(ArtNode* ArtNode, ArtNode** nodeRef, uint8_t key[],
         // unsigned depth, uintptr_t value, unsigned maxKeyLength)

--- a/src/bliss/bench_btree.h
+++ b/src/bliss/bench_btree.h
@@ -20,9 +20,12 @@ class BlissBTreeIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
         this->_index.bulk_load(values.begin(), values.end());
     }
 
-    bool get(KEY_TYPE key) override { return this->_index.exists(key); }
+    bool get(KEY_TYPE key) override {
+        std::cout << key << " <- get " << this->_index.exists(key) << std::endl;
+        return this->_index.exists(key); }
 
     void put(KEY_TYPE key, VALUE_TYPE value) override {
+        std::cout << key << " <- put" << std::endl;
         this->_index.insert(std::make_pair(key, value));
     }
 

--- a/src/bliss/bench_btree.h
+++ b/src/bliss/bench_btree.h
@@ -21,11 +21,9 @@ class BlissBTreeIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
     }
 
     bool get(KEY_TYPE key) override {
-        std::cout << key << " <- get " << this->_index.exists(key) << std::endl;
         return this->_index.exists(key); }
 
     void put(KEY_TYPE key, VALUE_TYPE value) override {
-        std::cout << key << " <- put" << std::endl;
         this->_index.insert(std::make_pair(key, value));
     }
 

--- a/src/bliss/util/execute.h
+++ b/src/bliss/util/execute.h
@@ -1,50 +1,3 @@
-// #ifndef BLISS_EXECUTE_H
-// #define BLISS_EXECUTE_H
-// #include <iostream>
-// #include <random>
-// #include <vector>
-
-// #include "bliss/bliss_index.h"
-
-// typedef unsigned long key_type;
-// typedef unsigned long value_type;
-
-// namespace bliss {
-// namespace utils {
-// namespace executor {
-// void execute_inserts(bliss::BlissIndex<key_type, value_type> &tree,
-//                      std::vector<key_type>::iterator &start,
-//                      std::vector<key_type>::iterator &end, int seed = 0) {
-//     spdlog::trace("Executing Inserts");
-//     std::mt19937 gen(seed);
-//     std::uniform_int_distribution<value_type> dist(0, 1);
-
-//     auto num_keys = end - start;
-//     for (auto &curr = start; curr != end; ++curr) {
-//         tree.put(*curr, std::round(dist(gen) * num_keys));
-//     }
-// }
-
-// void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
-//                              std::vector<key_type> &data, int num_reads,
-//                              int seed = 0) {
-//     std::mt19937 gen(seed);
-//     std::uniform_int_distribution<int> dist(0, 1);
-
-//     size_t key_idx;
-//     for (auto blank = 0; blank < num_reads; blank++) {
-//         key_idx = std::round(dist(gen) * (data.size() - 1));
-//         tree.get(data.at(key_idx));
-//     }
-// }
-
-// }  // namespace executor
-// }  // namespace utils
-// }  // namespace bliss
-// #endif
-
-
-
 #ifndef BLISS_EXECUTE_H
 #define BLISS_EXECUTE_H
 
@@ -69,7 +22,7 @@ void execute_inserts(bliss::BlissIndex<key_type, value_type> &tree,
     spdlog::trace("Executing Inserts");
     std::mt19937 gen(seed);
     auto num_keys = std::distance(start, end);
-    std::uniform_int_distribution<value_type> dist(0, num_keys - 1);
+    std::uniform_int_distribution<size_t> dist(0, num_keys - 1);
 
     for (auto curr = start; curr != end; ++curr) {
         tree.put(*curr, dist(gen));

--- a/src/bliss/util/execute.h
+++ b/src/bliss/util/execute.h
@@ -1,8 +1,58 @@
+// #ifndef BLISS_EXECUTE_H
+// #define BLISS_EXECUTE_H
+// #include <iostream>
+// #include <random>
+// #include <vector>
+
+// #include "bliss/bliss_index.h"
+
+// typedef unsigned long key_type;
+// typedef unsigned long value_type;
+
+// namespace bliss {
+// namespace utils {
+// namespace executor {
+// void execute_inserts(bliss::BlissIndex<key_type, value_type> &tree,
+//                      std::vector<key_type>::iterator &start,
+//                      std::vector<key_type>::iterator &end, int seed = 0) {
+//     spdlog::trace("Executing Inserts");
+//     std::mt19937 gen(seed);
+//     std::uniform_int_distribution<value_type> dist(0, 1);
+
+//     auto num_keys = end - start;
+//     for (auto &curr = start; curr != end; ++curr) {
+//         tree.put(*curr, std::round(dist(gen) * num_keys));
+//     }
+// }
+
+// void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
+//                              std::vector<key_type> &data, int num_reads,
+//                              int seed = 0) {
+//     std::mt19937 gen(seed);
+//     std::uniform_int_distribution<int> dist(0, 1);
+
+//     size_t key_idx;
+//     for (auto blank = 0; blank < num_reads; blank++) {
+//         key_idx = std::round(dist(gen) * (data.size() - 1));
+//         tree.get(data.at(key_idx));
+//     }
+// }
+
+// }  // namespace executor
+// }  // namespace utils
+// }  // namespace bliss
+// #endif
+
+
+
 #ifndef BLISS_EXECUTE_H
 #define BLISS_EXECUTE_H
+
 #include <iostream>
 #include <random>
 #include <vector>
+#include <cmath>
+#include <spdlog/spdlog.h>
 
 #include "bliss/bliss_index.h"
 
@@ -12,28 +62,29 @@ typedef unsigned long value_type;
 namespace bliss {
 namespace utils {
 namespace executor {
+
 void execute_inserts(bliss::BlissIndex<key_type, value_type> &tree,
-                     std::vector<key_type>::iterator &start,
-                     std::vector<key_type>::iterator &end, int seed = 0) {
+                     std::vector<key_type>::iterator start,
+                     std::vector<key_type>::iterator end, int seed = 0) {
     spdlog::trace("Executing Inserts");
     std::mt19937 gen(seed);
-    std::uniform_int_distribution<value_type> dist(0, 1);
+    auto num_keys = std::distance(start, end);
+    std::uniform_int_distribution<value_type> dist(0, num_keys - 1);
 
-    auto num_keys = end - start;
-    for (auto &curr = start; curr != end; ++curr) {
-        tree.put(*curr, std::round(dist(gen) * num_keys));
+    for (auto curr = start; curr != end; ++curr) {
+        tree.put(*curr, dist(gen));
     }
 }
 
 void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
-                             std::vector<key_type> &data, int num_reads,
+                             const std::vector<key_type> &data, int num_reads,
                              int seed = 0) {
+    spdlog::trace("Executing Non-Empty Reads");
     std::mt19937 gen(seed);
-    std::uniform_int_distribution<int> dist(0, 1);
+    std::uniform_int_distribution<size_t> dist(0, data.size() - 1);
 
-    size_t key_idx;
-    for (auto blank = 0; blank < num_reads; blank++) {
-        key_idx = std::round(dist(gen) * (data.size() - 1));
+    for (int i = 0; i < num_reads; ++i) {
+        size_t key_idx = dist(gen);
         tree.get(data.at(key_idx));
     }
 }
@@ -41,4 +92,5 @@ void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
 }  // namespace executor
 }  // namespace utils
 }  // namespace bliss
+
 #endif

--- a/src/bliss_bench.cpp
+++ b/src/bliss_bench.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "bliss/bench_alex.h"
+#include "bliss/bench_art.h"
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
 #include "bliss/bliss_index.h"
@@ -168,6 +169,8 @@ int main(int argc, char *argv[]) {
         index.reset(new bliss::BlissLippIndex<key_type, value_type>());
     } else if (config.index == "btree") {
         index.reset(new bliss::BlissBTreeIndex<key_type, value_type>());
+    } else if (config.index == "art") {
+        index.reset(new bliss::BlissARTIndex<key_type, value_type>());
     } else {
         spdlog::error(config.index + " not implemented yet", 1);
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,4 @@ target_include_directories(bliss_test_infra PUBLIC
 add_subdirectory(test_alex)
 add_subdirectory(test_lipp)
 add_subdirectory(test_btree)
+add_subdirectory(test_art)

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -33,7 +33,7 @@ class BlissIndexTest : public testing::Test
 {
   protected:
     std::unique_ptr<bliss::BlissIndex<key_type, value_type>> index;
-    std::string indexes[4] = {"alex", "lipp", "btree", "pgm", "art"};
+    std::string indexes[5] = {"alex", "lipp", "btree", "pgm", "art"};
     int num_keys = 100000;
 
     void SetUp()

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -8,6 +8,8 @@
 #include <cxxopts.hpp>
 #include <iostream>
 #include <string>
+#include <algorithm>
+#include <random>
 
 #include "bliss/bench_alex.h"
 #include "bliss/bench_art.h"
@@ -28,7 +30,7 @@ using value_type = unsigned long;
 class BlissIndexTest : public testing::Test {
    protected:
     std::unique_ptr<bliss::BlissIndex<key_type, value_type>> index;
-    std::string indexes[3] = {"alex", "lipp", "btree"};
+    std::string indexes[4] = {"alex", "lipp", "btree", "art"};
     int num_keys = 100000;
 
     void SetUp() {}
@@ -39,7 +41,9 @@ class BlissIndexTest : public testing::Test {
             data.push_back(i);
         }
         if (!sorted) {
-            std::random_shuffle(data.begin(), data.end());
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(data.begin(), data.end(), g);
         }
     }
 };

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "bliss/bench_alex.h"
+#include "bliss/bench_art.h"
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
 #include "bliss/bliss_index.h"

--- a/tests/test_art/CMakeLists.txt
+++ b/tests/test_art/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_filename_component(EXEC ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+file(GLOB_RECURSE CPP_TESTS "*_tests.cpp")
+add_executable(${EXEC} ${CPP_TESTS})
+target_link_libraries(${EXEC} PRIVATE 
+bliss
+bliss_test_infra 
+GTest::gtest_main)
+include(GoogleTest)
+gtest_discover_tests(${EXEC})

--- a/tests/test_art/art_tests.cpp
+++ b/tests/test_art/art_tests.cpp
@@ -1,0 +1,31 @@
+#include "bliss_index_tests.h"
+
+class ArtTest : public BlissIndexTest {};
+
+TEST_F(ArtTest, TestArt_Sorted) {
+    index.reset(new bliss::BlissARTIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}
+
+TEST_F(ArtTest, TestArt_Random) {
+    index.reset(new bliss::BlissARTIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys, false);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    for (auto key : data) {
+        EXPECT_TRUE(index->get(key));
+    }
+}

--- a/tests/test_art/art_tests.cpp
+++ b/tests/test_art/art_tests.cpp
@@ -2,6 +2,17 @@
 
 class ArtTest : public BlissIndexTest {};
 
+
+TEST_F(ArtTest, TestArt_Sanity) {
+    index.reset(new bliss::BlissARTIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    int key = 100'000;
+    int value = 123'456;
+    index->put(key, value);
+    EXPECT_TRUE(index->get(key));
+}
+
+
 TEST_F(ArtTest, TestArt_Sorted) {
     index.reset(new bliss::BlissARTIndex<key_type, key_type>());
     std::vector<key_type> data;


### PR DESCRIPTION
This PR integrates the Adaptive Radix Tree [Leis, et.al.] into the BLISS benchmark. 

## Added Functionality: 
- Imports an internal BU-DiSC fork of ART as a CMake library
- Adds corresponding adapters for integration
- Adds unit tests for basic sanity check, similar to other indexes

## Modified files: 
- `CMakeLists.txt` 
- `external/CMakeLists.txt`
- `src/bliss_bench.cpp`
- `tests/CMakeLists.txt`
- `tests/bliss_index_tests.h`
- .`gitignore`