### PR TITLE
Jsl yoon/skip list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(bliss OBJECT
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_lipp.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_alex.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_btree.h
+    ${CMAKE_SOURCE_DIR}/src/bliss/bench_skiplist.h
 )
 
 target_compile_features(bliss PUBLIC
@@ -63,6 +64,7 @@ target_link_libraries(bliss PUBLIC
     alex
     lipp
     tlx
+    skiplist
 )
 
 target_include_directories(bliss PUBLIC

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -33,7 +33,7 @@ FetchContent_MakeAvailable(cxxopts)
 
 FetchContent_Declare(
     alex
-    GIT_REPOSITORY https://github.com/microsoft/ALEX.git
+    GIT_REPOSITORY https://github.com/microsoft/ALEX
     GIT_TAG master
 )
 FetchContent_GetProperties(alex)
@@ -84,4 +84,4 @@ if (NOT skiplist_POPULATED)
 endif()
 
 add_library(skiplist INTERFACE)
-target_include_directories(skiplist INTERFACE ${skiplist_SOURCE_DIR}/src/core)
+target_include_directories(skiplist INTERFACE ${skiplist_SOURCE_DIR}/skiplist)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -71,3 +71,17 @@ endif()
 
 add_library(tlx INTERFACE)
 target_include_directories(tlx INTERFACE ${tlx_SOURCE_DIR}/)
+
+
+FetchContent_Declare(
+    skiplist
+    GIT_REPOSITORY https://github.com/Samyak2/skip-list.git
+    GIT_TAG main
+)
+FetchContent_GetProperties(skiplist)
+if (NOT skiplist_POPULATED)
+    FetchContent_Populate(skiplist)
+endif()
+
+add_library(skiplist INTERFACE)
+target_include_directories(skiplist INTERFACE ${skiplist_SOURCE_DIR}/src/core)

--- a/src/bliss/bench_skiplist.h
+++ b/src/bliss/bench_skiplist.h
@@ -4,14 +4,14 @@
 #include <vector>
 
 #include "bliss/bliss_index.h"
-#include "skiplist/skiplist.hpp"
+#include "skiplist_map.hpp"
 
 namespace bliss {
 
 template <typename KEY_TYPE, typename VALUE_TYPE>
 class BlissSkipListIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
    public:
-    skiplist::skiplist<KEY_TYPE, VALUE_TYPE> _index;
+    skiplist<KEY_TYPE, VALUE_TYPE> _index;
     BlissSkipListIndex() : _index(){};
 
     void bulkload(

--- a/src/bliss/bench_skiplist.h
+++ b/src/bliss/bench_skiplist.h
@@ -1,0 +1,33 @@
+#ifndef BLISS_BENCH_SKIPLIST
+#define BLISS_BENCH_SKIPLIST
+
+#include <vector>
+
+#include "bliss/bliss_index.h"
+#include "skiplist/skiplist.hpp"
+
+namespace bliss {
+
+template <typename KEY_TYPE, typename VALUE_TYPE>
+class BlissSkipListIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
+   public:
+    skiplist::skiplist<KEY_TYPE, VALUE_TYPE> _index;
+    BlissSkipListIndex() : _index(){};
+
+    void bulkload(
+        std::vector<std::pair<KEY_TYPE, VALUE_TYPE>> values) override {
+        for (const auto& pair : values) {
+            _index.insert(pair.first, pair.second);
+        }
+    }
+
+    bool get(KEY_TYPE key) override { return _index.find(key) != _index.end(); }
+
+    void put(KEY_TYPE key, VALUE_TYPE value) override { _index.insert(key, value); }
+
+    void end_routine() override {}
+};
+
+}  // namespace bliss
+
+#endif  // !BLISS_BENCH_SKIPLIST

--- a/src/bliss_bench.cpp
+++ b/src/bliss_bench.cpp
@@ -1,5 +1,6 @@
 #include <alex.h>
 #include <lipp.h>
+#include "skiplist/skiplist.h"
 #include <spdlog/common.h>
 
 #include <cxxopts.hpp>
@@ -9,6 +10,7 @@
 #include "bliss/bench_alex.h"
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
+#include "bliss/bench_skiplist.h"
 #include "bliss/bliss_index.h"
 #include "bliss/util/args.h"
 #include "bliss/util/config.h"
@@ -168,6 +170,8 @@ int main(int argc, char *argv[]) {
         index.reset(new bliss::BlissLippIndex<key_type, value_type>());
     } else if (config.index == "btree") {
         index.reset(new bliss::BlissBTreeIndex<key_type, value_type>());
+    } else if (config.index == "skiplist") {
+        index.reset(new bliss::BlissSkipListIndex<key_type, value_type>());
     } else {
         spdlog::error(config.index + " not implemented yet", 1);
     }

--- a/src/bliss_bench.cpp
+++ b/src/bliss_bench.cpp
@@ -1,6 +1,6 @@
 #include <alex.h>
 #include <lipp.h>
-#include "skiplist/skiplist.h"
+#include "skiplist_map.hpp"
 #include <spdlog/common.h>
 
 #include <cxxopts.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,4 @@ target_include_directories(bliss_test_infra PUBLIC
 add_subdirectory(test_alex)
 add_subdirectory(test_lipp)
 add_subdirectory(test_btree)
+add_subdirectory(test_skiplist)

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -8,10 +8,13 @@
 #include <cxxopts.hpp>
 #include <iostream>
 #include <string>
+#include <algorithm>
+#include <random>
 
 #include "bliss/bench_alex.h"
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
+#include "bliss/bench_skiplist.h"
 #include "bliss/bliss_index.h"
 #include "bliss/util/args.h"
 #include "bliss/util/config.h"
@@ -27,7 +30,7 @@ using value_type = unsigned long;
 class BlissIndexTest : public testing::Test {
    protected:
     std::unique_ptr<bliss::BlissIndex<key_type, value_type>> index;
-    std::string indexes[3] = {"alex", "lipp", "btree"};
+    std::string indexes[4] = {"alex", "lipp", "btree", "skiplist"};
     int num_keys = 100000;
 
     void SetUp() {}
@@ -38,7 +41,9 @@ class BlissIndexTest : public testing::Test {
             data.push_back(i);
         }
         if (!sorted) {
-            std::random_shuffle(data.begin(), data.end());
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(data.begin(), data.end(), g);
         }
     }
 };

--- a/tests/test_skiplist/CMakeLists.txt
+++ b/tests/test_skiplist/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_filename_component(EXEC ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+file(GLOB_RECURSE CPP_TESTS "*_tests.cpp")
+add_executable(${EXEC} ${CPP_TESTS})
+target_link_libraries(${EXEC} PRIVATE 
+bliss
+bliss_test_infra 
+GTest::gtest_main)
+include(GoogleTest)
+gtest_discover_tests(${EXEC})

--- a/tests/test_skiplist/skiplist_tests.cpp
+++ b/tests/test_skiplist/skiplist_tests.cpp
@@ -1,9 +1,9 @@
 #include "bliss_index_tests.h"
 
-class LippTest : public BlissIndexTest {};
+class SkipListTest : public BlissIndexTest {};
 
-TEST_F(LippTest, TestLipp_Sorted) {
-    index.reset(new bliss::BlissLippIndex<key_type, key_type>());
+TEST_F(SkipListTest, TestSkipList_Sorted) {
+    index.reset(new bliss::BlissSkipListIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys);
 
@@ -16,8 +16,8 @@ TEST_F(LippTest, TestLipp_Sorted) {
     }
 }
 
-TEST_F(LippTest, TestLipp_Random) {
-    index.reset(new bliss::BlissLippIndex<key_type, key_type>());
+TEST_F(SkipListTest, TestSkipList_Random) {
+    index.reset(new bliss::BlissSkipListIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys, false);
 


### PR DESCRIPTION
Adding new feature:
added new index, skip list
added unit test for skip list

Bug fixes:
Used Lipp index for Alex test (typo), fixed
Using function that's no longer supported: std::random_shuffle -> std::shuffle