### PR TITLE
adding pgm index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(bliss OBJECT
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_lipp.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_alex.h
     ${CMAKE_SOURCE_DIR}/src/bliss/bench_btree.h
+    ${CMAKE_SOURCE_DIR}/src/bliss/bench_pgm.h
 )
 
 target_compile_features(bliss PUBLIC
@@ -63,6 +64,7 @@ target_link_libraries(bliss PUBLIC
     alex
     lipp
     tlx
+    pgm
 )
 
 target_include_directories(bliss PUBLIC

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(alex INTERFACE ${alex_SOURCE_DIR}/src/core)
 
 FetchContent_Declare(
     lipp
-    GIT_REPOSITORY https://github.com/Jiacheng-WU/lipp
+    GIT_REPOSITORY https://github.com/Jiacheng-WU/lipp.git
     GIT_TAG main
 )
 FetchContent_GetProperties(lipp)
@@ -71,3 +71,19 @@ endif()
 
 add_library(tlx INTERFACE)
 target_include_directories(tlx INTERFACE ${tlx_SOURCE_DIR}/)
+
+
+
+
+FetchContent_Declare(
+    pgm
+    GIT_REPOSITORY https://github.com/gvinciguerra/PGM-index
+    GIT_TAG master
+)
+FetchContent_GetProperties(pgm)
+if (NOT pgm_POPULATED)
+    FetchContent_Populate(pgm)
+endif()
+
+add_library(pgm INTERFACE)
+target_include_directories(pgm INTERFACE ${pgm_SOURCE_DIR})

--- a/src/bliss/bench_pgm.h
+++ b/src/bliss/bench_pgm.h
@@ -12,7 +12,6 @@ namespace bliss {
 template <typename KEY_TYPE, typename VALUE_TYPE>
 class BlissPGMIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
    public:
-    // pgm::PGMIndex<int, epsilon> _index();
     pgm::DynamicPGMIndex<KEY_TYPE, VALUE_TYPE> _index;
     BlissPGMIndex() : _index(){};
 

--- a/src/bliss/bench_pgm.h
+++ b/src/bliss/bench_pgm.h
@@ -1,0 +1,39 @@
+#ifndef BLISS_BENCH_PGM
+#define BLISS_BENCH_PGM
+
+#include <vector>
+
+#include "bliss/bliss_index.h"
+#include "include/pgm/pgm_index_dynamic.hpp"
+
+
+namespace bliss {
+
+template <typename KEY_TYPE, typename VALUE_TYPE>
+class BlissPGMIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
+   public:
+    // pgm::PGMIndex<int, epsilon> _index();
+    pgm::DynamicPGMIndex<KEY_TYPE, VALUE_TYPE> _index;
+    BlissPGMIndex() : _index(){};
+
+    void bulkload(
+        std::vector<std::pair<KEY_TYPE, VALUE_TYPE>> values) override {
+        // expects the pairs to be pre-sorted before performing bulk load
+        for (const auto& pair : values) {
+            this->put(pair.first, pair.second);
+        }
+    }
+
+    bool get(KEY_TYPE key) override {
+        auto it = _index.find(key);
+        return it != _index.end();
+    }
+
+    void put(KEY_TYPE key, VALUE_TYPE value) override { _index.insert_or_assign(key, value); }
+
+    void end_routine() override {}
+};
+
+}  // namespace bliss
+
+#endif  // !BLISS_BENCH_PGM

--- a/src/bliss_bench.cpp
+++ b/src/bliss_bench.cpp
@@ -1,11 +1,13 @@
 #include <alex.h>
 #include <lipp.h>
 #include <spdlog/common.h>
+#include "include/pgm/pgm_index_dynamic.hpp"
 
 #include <cxxopts.hpp>
 #include <iostream>
 #include <string>
 
+#include "bliss/bench_pgm.h"
 #include "bliss/bench_alex.h"
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
@@ -168,6 +170,8 @@ int main(int argc, char *argv[]) {
         index.reset(new bliss::BlissLippIndex<key_type, value_type>());
     } else if (config.index == "btree") {
         index.reset(new bliss::BlissBTreeIndex<key_type, value_type>());
+    } else if (config.index == "pgm") {
+        index.reset(new bliss::BlissPGMIndex<key_type, value_type>());
     } else {
         spdlog::error(config.index + " not implemented yet", 1);
     }

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -4,11 +4,15 @@
 #include <gtest/gtest.h>
 #include <lipp.h>
 #include <spdlog/common.h>
+#include "include/pgm/pgm_index_dynamic.hpp"
 
 #include <cxxopts.hpp>
 #include <iostream>
 #include <string>
+#include <algorithm>
+#include <random>
 
+#include "bliss/bench_pgm.h"
 #include "bliss/bench_alex.h"
 #include "bliss/bench_btree.h"
 #include "bliss/bench_lipp.h"
@@ -38,7 +42,9 @@ class BlissIndexTest : public testing::Test {
             data.push_back(i);
         }
         if (!sorted) {
-            std::random_shuffle(data.begin(), data.end());
+            std::random_device rd;
+            std::mt19937 g(rd());
+            std::shuffle(data.begin(), data.end(), g);
         }
     }
 };

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -31,7 +31,7 @@ using value_type = unsigned long;
 class BlissIndexTest : public testing::Test {
    protected:
     std::unique_ptr<bliss::BlissIndex<key_type, value_type>> index;
-    std::string indexes[3] = {"alex", "lipp", "btree", "pgm"};
+    std::string indexes[4] = {"alex", "lipp", "btree", "pgm"};
     int num_keys = 100000;
 
     void SetUp() {}

--- a/tests/bliss_index_tests.h
+++ b/tests/bliss_index_tests.h
@@ -31,7 +31,7 @@ using value_type = unsigned long;
 class BlissIndexTest : public testing::Test {
    protected:
     std::unique_ptr<bliss::BlissIndex<key_type, value_type>> index;
-    std::string indexes[3] = {"alex", "lipp", "btree"};
+    std::string indexes[3] = {"alex", "lipp", "btree", "pgm"};
     int num_keys = 100000;
 
     void SetUp() {}

--- a/tests/test_pgm/CMakeLists.txt
+++ b/tests/test_pgm/CMakeLists.txt
@@ -1,0 +1,9 @@
+get_filename_component(EXEC ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+file(GLOB_RECURSE CPP_TESTS "*_tests.cpp")
+add_executable(${EXEC} ${CPP_TESTS})
+target_link_libraries(${EXEC} PRIVATE 
+bliss
+bliss_test_infra 
+GTest::gtest_main)
+include(GoogleTest)
+gtest_discover_tests(${EXEC})

--- a/tests/test_pgm/pgm_tests.cpp
+++ b/tests/test_pgm/pgm_tests.cpp
@@ -1,9 +1,20 @@
 #include "bliss_index_tests.h"
 
-class BTreeTest : public BlissIndexTest {};
+class PGMTest : public BlissIndexTest {};
 
-TEST_F(BTreeTest, TestBTree_Sorted) {
-    index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
+
+TEST_F(PGMTest, TestPGM_Sanity) {
+    index.reset(new bliss::PGMIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    int key = 100'000;
+    int value = 123'456;
+    index->put(key, value);
+    EXPECT_TRUE(index->get(key));
+}
+
+
+TEST_F(PGMTest, TestPGM_Sorted) {
+    index.reset(new bliss::PGMIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys);
 
@@ -16,8 +27,9 @@ TEST_F(BTreeTest, TestBTree_Sorted) {
     }
 }
 
-TEST_F(BTreeTest, TestBTree_Random) {
-    index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
+
+TEST_F(PGMTest, TestPGM_Random) {
+    index.reset(new bliss::PGMIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys, false);
 

--- a/tests/test_pgm/pgm_tests.cpp
+++ b/tests/test_pgm/pgm_tests.cpp
@@ -1,8 +1,8 @@
 #include "bliss_index_tests.h"
 
-class PGMTest : public BlissIndexTest {};
+class BTreeTest : public BlissIndexTest {};
 
-TEST_F(PGMTest, TestPGM_Sorted) {
+TEST_F(BTreeTest, TestBTree_Sorted) {
     index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys);
@@ -16,7 +16,7 @@ TEST_F(PGMTest, TestPGM_Sorted) {
     }
 }
 
-TEST_F(PGMTest, TestPGM_Random) {
+TEST_F(BTreeTest, TestBTree_Random) {
     index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys, false);


### PR DESCRIPTION
Added Functionality:

- Adding pgm-index to bliss; using imported https://github.com/gvinciguerra/PGM-index/tree/master library.
- Using pgm-index-dynamic because the original pgm-index does not support for dynamic operations (get, put, update, etc).



