### PR TITLE
[Refactor] renamed PGMTest class in BTreeTests to BTreeTest

### DIFF
--- a/tests/test_btree/btree_tests.cpp
+++ b/tests/test_btree/btree_tests.cpp
@@ -1,8 +1,17 @@
 #include "bliss_index_tests.h"
 
-class PGMTest : public BlissIndexTest {};
+class BTreeTest : public BlissIndexTest {};
 
-TEST_F(PGMTest, TestPGM_Sorted) {
+TEST_F(BTreeTest, TestBtree_Sanity) {
+    index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    int key = 100;
+    int value = 123;
+    index->put(key, value);
+    EXPECT_TRUE(index->get(key));
+}
+
+TEST_F(BTreeTest, TestBtree_Sorted) {
     index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys);
@@ -16,7 +25,7 @@ TEST_F(PGMTest, TestPGM_Sorted) {
     }
 }
 
-TEST_F(PGMTest, TestPGM_Random) {
+TEST_F(BTreeTest, TestBTree_Random) {
     index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
     std::vector<key_type> data;
     GenerateData(data, num_keys, false);


### PR DESCRIPTION
The BTreeTest suite had its class name as PGMTest which appears to be some refactor error from an earlier PR merge. This PR fixes the issue and also adds the sanity check test for the tlx::BTree. 

