### PR TITLE
range queries

### DIFF
--- a/src/bliss/bench_alex.h
+++ b/src/bliss/bench_alex.h
@@ -14,7 +14,7 @@ template <typename KEY_TYPE, typename VALUE_TYPE>
 class BlissAlexIndex : public BlissIndex<KEY_TYPE, VALUE_TYPE> {
    public:
     alex::Alex<KEY_TYPE, VALUE_TYPE> _index;
-    BlissAlexIndex() : _index(){};
+    BlissAlexIndex() : _index() {};
 
     void bulkload(
         std::vector<std::pair<KEY_TYPE, VALUE_TYPE>> values) override {

--- a/src/bliss/util/args.h
+++ b/src/bliss/util/args.h
@@ -36,7 +36,11 @@ BlissConfig parse_args(int argc, char *argv[]) {
             "file_type", "Input file type [binary | txt]",
             cxxopts::value<std::string>()->default_value("txt"))(
             "use_preload", "Use index defined preload",
-            cxxopts::value<bool>()->default_value("false"));
+            cxxopts::value<bool>()->default_value("false"))(
+            "range-query", "Range query factor",
+            cxxopts::value<double>()->default_value("0.0"))(
+            "selectivity", "Selectivity factor (percentage of domain)",
+            cxxopts::value<double>()->default_value("0.01"));
 
         auto result = options.parse(argc, argv);
         config = {
@@ -51,6 +55,8 @@ BlissConfig parse_args(int argc, char *argv[]) {
             .index = result["index"].as<std::string>(),
             .file_type = result["file_type"].as<std::string>(),
             .use_preload = result["use_preload"].as<bool>(),
+            .range_query_factor = result["range-query"].as<double>(),
+            .selectivity_factor = result["selectivity"].as<double>(),
         };
     } catch (const std::exception &e) {
         std::cerr << "Error: " << e.what() << std::endl;

--- a/src/bliss/util/config.h
+++ b/src/bliss/util/config.h
@@ -19,6 +19,8 @@ struct BlissConfig {
     std::string index;
     std::string file_type;
     bool use_preload;
+    double range_query_factor = 0.0;
+    double selectivity_factor = 0.01;
 };
 
 void display_config(BlissConfig config) {
@@ -30,6 +32,9 @@ void display_config(BlissConfig config) {
     spdlog::trace("Verbosity {}", config.verbosity);
     spdlog::trace("Index: {}", config.index);
     spdlog::trace("File type: {}", config.file_type);
+    spdlog::trace("Use Preload: {}", config.use_preload);
+    spdlog::trace("Range Query Factor: {}", config.range_query_factor);
+    spdlog::trace("Selectivity Factor: {}", config.selectivity_factor);
 }
 }  // namespace config
 }  // namespace utils

--- a/src/bliss/util/execute.h
+++ b/src/bliss/util/execute.h
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <random>
 #include <vector>
+#include <algorithm>
 
 #include "bliss/bliss_index.h"
 
@@ -40,6 +41,26 @@ void execute_non_empty_reads(bliss::BlissIndex<key_type, value_type> &tree,
     for (int i = 0; i < num_reads; ++i) {
         size_t key_idx = dist(gen);
         tree.get(data.at(key_idx));
+    }
+}
+
+void execute_range_queries(bliss::BlissIndex<key_type, value_type> &tree,
+                          const std::vector<key_type> &data, int num_queries,
+                          double selectivity = 0.01, int seed = 0) {
+    spdlog::trace("Executing Range Queries");
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<size_t> key_dist(0, data.size() - 1);
+    
+    key_type data_range = *std::max_element(data.begin(), data.end()) - 
+                          *std::min_element(data.begin(), data.end());
+    key_type avg_range_size = static_cast<key_type>(data_range * selectivity);
+    
+    for (int i = 0; i < num_queries; ++i) {
+        size_t start_idx = key_dist(gen);
+        key_type start_key = data.at(start_idx);
+        key_type end_key = start_key + avg_range_size;
+        
+        tree.get(start_key, end_key);
     }
 }
 

--- a/tests/test_alex/alex_tests.cpp
+++ b/tests/test_alex/alex_tests.cpp
@@ -1,6 +1,27 @@
 #include "bliss_index_tests.h"
 
 class AlexTest : public BlissIndexTest {};
+
+TEST_F(AlexTest, TestAlex_RangeQuery) {
+    index.reset(new bliss::BlissAlexIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(AlexTest, TestAlex_Sorted) {
     index.reset(new bliss::BlissAlexIndex<key_type, key_type>());
     std::vector<key_type> data;

--- a/tests/test_art/art_tests.cpp
+++ b/tests/test_art/art_tests.cpp
@@ -11,6 +11,26 @@ TEST_F(ArtTest, TestArt_Sanity) {
     EXPECT_TRUE(index->get(key));
 }
 
+TEST_F(ArtTest, TestArt_RangeQuery) {
+    index.reset(new bliss::BlissARTIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(ArtTest, TestArt_Sorted) {
     index.reset(new bliss::BlissARTIndex<key_type, key_type>());
     std::vector<key_type> data;

--- a/tests/test_btree/btree_tests.cpp
+++ b/tests/test_btree/btree_tests.cpp
@@ -11,6 +11,26 @@ TEST_F(BTreeTest, TestBtree_Sanity) {
     EXPECT_TRUE(index->get(key));
 }
 
+TEST_F(BTreeTest, TestBtree_RangeQuery) {
+    index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(BTreeTest, TestBtree_Sorted) {
     index.reset(new bliss::BlissBTreeIndex<key_type, key_type>());
     std::vector<key_type> data;

--- a/tests/test_imprints/imprint_tests.cpp
+++ b/tests/test_imprints/imprint_tests.cpp
@@ -2,6 +2,26 @@
 
 class ImprintsTest : public BlissIndexTest {};
 
+TEST_F(ImprintsTest, TestImprint_RangeQuery) {
+    index.reset(new bliss::BlissImprintsIndex<size_t, key_type>(64, 64, std::string("unsigned long")));
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(ImprintsTest, TestImprint_Random) {
     index.reset(new bliss::BlissImprintsIndex<size_t, key_type>(64, 64, std::string("unsigned long")));
     std::vector<key_type> data;

--- a/tests/test_leveldb/leveldb_tests.cpp
+++ b/tests/test_leveldb/leveldb_tests.cpp
@@ -11,6 +11,26 @@ TEST_F(LevelDBTest, TestLevelDB_Sanity) {
     EXPECT_TRUE(index->get(key));
 }
 
+TEST_F(LevelDBTest, TestLevelDB_RangeQuery) {
+    index.reset(new bliss::BlissLevelDBIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(LevelDBTest, TestLevelDB_Sorted) {
     index.reset(new bliss::BlissLevelDBIndex<key_type, key_type>());
     std::vector<key_type> data;

--- a/tests/test_lipp/lipp_tests.cpp
+++ b/tests/test_lipp/lipp_tests.cpp
@@ -2,6 +2,26 @@
 
 class LippTest : public BlissIndexTest {};
 
+TEST_F(LippTest, TestLipp_RangeQuery) {
+    index.reset(new bliss::BlissLippIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(LippTest, TestLipp_Sorted) {
     index.reset(new bliss::BlissLippIndex<key_type, key_type>());
     std::vector<key_type> data;

--- a/tests/test_pgm/pgm_tests.cpp
+++ b/tests/test_pgm/pgm_tests.cpp
@@ -11,6 +11,26 @@ TEST_F(PGMTest, TestPGM_Sanity) {
     EXPECT_TRUE(index->get(key));
 }
 
+TEST_F(PGMTest, TestPGM_RangeQuery) {
+    index.reset(new bliss::PGMIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED();
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(PGMTest, TestPGM_Sorted) {
     index.reset(new bliss::PGMIndex<key_type, key_type>());
     std::vector<key_type> data;

--- a/tests/test_skiplist/skiplist_tests.cpp
+++ b/tests/test_skiplist/skiplist_tests.cpp
@@ -11,6 +11,26 @@ TEST_F(SkipListTest, TestSkipList_Sanity) {
     EXPECT_TRUE(index->get(key));
 }
 
+TEST_F(SkipListTest, TestSkipList_RangeQuery) {
+    index.reset(new bliss::BlissSkipListIndex<key_type, key_type>());
+    std::vector<key_type> data;
+    GenerateData(data, num_keys);
+
+    auto insert_start = data.begin();
+    auto insert_end = data.end();
+    executor::execute_inserts(*index, insert_start, insert_end);
+
+    key_type start_key = data.front();
+    key_type end_key = start_key + (data.back() - data.front()) / 4;
+    
+    try {
+        index->get(start_key, end_key);
+        SUCCEED(); 
+    } catch (const std::runtime_error& e) {
+        EXPECT_STREQ("Not implemented", e.what());
+    }
+}
+
 TEST_F(SkipListTest, TestSkipList_Sorted) {
     index.reset(new bliss::BlissSkipListIndex<key_type, key_type>());
     std::vector<key_type> data;


### PR DESCRIPTION
Adding range query execution for all indexes if they exist. Modularized the code so that there exists a function for processing point queries, and there is a function that processes range queries (if they exist). 
Two additional input were added, which is num_range_queries, and selectivity